### PR TITLE
Add support url parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,10 +13,10 @@ module.exports = function(opts, cb) {
     return {
       name: 'LINK_INTERCEPTOR',
       onStart: function() {
-        document.addEventListener('click', clickHandler, false);
+        document.addEventListener(clickEvent, clickHandler, false);
       },
       onStop: function() {
-        document.removeEventListener('click', clickHandler);
+        document.removeEventListener(clickEvent, clickHandler);
       }
     };
   };

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ function onClick(router, opts, cb) {
     if (toRouteState) {
       e.preventDefault();
       var name = toRouteState.name;
-      var params = getParams(el.href);
+      var params = Object.assign(getParams(el.href), toRouteState.params);
 
       var finalOpts;
       if (typeof opts === 'function') {

--- a/index.js
+++ b/index.js
@@ -22,6 +22,18 @@ module.exports = function(opts, cb) {
   };
 };
 
+function merge(object, other) {
+  var merged = {};
+  Object.keys(object || []).forEach(function (key) {
+    merged[key] = object[key];
+  });
+  Object.keys(other || []).forEach(function (key) {
+    merged[key] = other[key];
+  });
+
+  return merged;
+}
+
 function onClick(router, opts, cb) {
   function which(e) {
     e = e || window.event;
@@ -79,7 +91,7 @@ function onClick(router, opts, cb) {
     if (toRouteState) {
       e.preventDefault();
       var name = toRouteState.name;
-      var params = Object.assign(getParams(el.href), toRouteState.params);
+      var params = merge(getParams(el.href), toRouteState.params);
 
       var finalOpts;
       if (typeof opts === 'function') {


### PR DESCRIPTION
router5 uses the path-parser.
It can use [:param syntax](https://router5.js.org/guides/path-syntax#defining-parameters). so, link interceptor should be able to recognize parameters in url and pass them as params arguments in the navigate function.
I combined the query params with the url params ​​recognized by toRouteState.

This has been tested in router5 v5 and v6.
Thanks!